### PR TITLE
Allows to specify alert duration

### DIFF
--- a/src/ExNavigationAlertBar.js
+++ b/src/ExNavigationAlertBar.js
@@ -130,11 +130,15 @@ export default class ExNavigationAlertBar extends React.Component {
   }
 
   _show = () => {
+    const { currentAlertState } = this.state;
+    const { options } = currentAlertState
+    const duration = options.duration || ALERT_DISPLAY_TIME_MS
+
     this.setState({isVisible: true}, () => {
       this.requestAnimationFrame(() => {
         this._textContainerRef && this._textContainerRef.measure((l, t, w, height) => {
           this._animateIn(height);
-          this._timeout = this.setTimeout(this._dispatchHide, ALERT_DISPLAY_TIME_MS);
+          this._timeout = this.setTimeout(this._dispatchHide, duration);
         });
       });
     });


### PR DESCRIPTION
Specify duration in milliseconds through its options, as the other props.

E.g (using redux)

```
  const navigatorUID = store.getState().navigation.currentNavigatorUID
  store.dispatch(NavigationActions.showLocalAlert(
    navigatorUID, message, {
      text: textStyle || { color: '#000' },
      container: containerStyle || { backgroundColor: 'grey' },
      duration: 100000
    })
  )
```

Enhances https://github.com/exponentjs/ex-navigation/issues/53