### PR TITLE
New Style for Horizontal with NoAnimation in NavBar

### DIFF
--- a/src/ExNavigationStyles.js
+++ b/src/ExNavigationStyles.js
@@ -253,16 +253,43 @@ export const SlideHorizontalFixedNav: ExNavigationStyles = {
       };
     },
     /**
-     * Don't animate the nav
+     * Crossfade the left view
      */
     forLeft: (props) => {
-      return {};
+      const {position, scene, scenes} = props;
+      const {index} = scene;
+      return {
+        opacity: position.interpolate({
+          inputRange: [index - 1, index, index + 1],
+          outputRange: [0, barVisibleForSceneIndex(scenes, index) ? 1 : 0, 0],
+        }),
+      };
     },
+    /**
+     * Crossfade the title
+     */
     forCenter: (props) => {
-      return {};
+      const {position, scene, scenes} = props;
+      const {index} = scene;
+      return {
+        opacity: position.interpolate({
+          inputRange: [index - 1, index, index + 1],
+          outputRange: [0, barVisibleForSceneIndex(scenes, index) ? 1 : 0, 0],
+        }),
+      };
     },
+    /**
+     * Crossfade the right view
+     */
     forRight: (props) => {
-      return {};
+      const {position, scene, scenes} = props;
+      const {index} = scene;
+      return {
+        opacity: position.interpolate({
+          inputRange: [index - 1, index, index + 1],
+          outputRange: [0, barVisibleForSceneIndex(scenes, index) ? 1 : 0, 0],
+        }),
+      };
     },
     gestures: CardStackPanResponder.forHorizontal,
   }

--- a/src/ExNavigationStyles.js
+++ b/src/ExNavigationStyles.js
@@ -205,6 +205,69 @@ export const SlideHorizontalIOS: ExNavigationStyles = {
   gestures: CardStackPanResponder.forHorizontal,
 };
 
+
+export const SlideHorizontalFixedNav: ExNavigationStyles = {
+  configureTransition: configureSpringTransition,
+  sceneAnimations: customForHorizontal,
+  navigationBarAnimations: {
+    forContainer: (props, delta) => {
+      const {
+        layout,
+        position,
+        scene,
+        scenes,
+      } = props;
+
+      const index = scene.index;
+
+      const meVisible = barVisibleForSceneIndex(scenes, index);
+      let offset = layout.initWidth;
+      if (delta === 0) {
+        // default state
+        offset = meVisible ? offset : -offset;
+      } else {
+        // if we're pushing, get the previous scenes' visibility. If we're popping, get the scene ahead
+        const prevVisible = barVisibleForSceneIndex(scenes, index + (delta > 0 ? -1 : 1));
+        if (!prevVisible && meVisible) {
+          // when showing, if a push, move from right to left, otherwise if pop, move from left to right
+          offset = delta > 0 ? offset : -offset;
+        } else {
+          // when hiding, if a push, move from left to right, otherwise if a pop, move from right to left
+          offset = delta > 0 ? -offset : offset;
+        }
+      }
+
+      return {
+        transform: [
+          {
+            translateX: position.interpolate({
+              inputRange: [index - 1, index, index + 1],
+              outputRange: [
+                barVisibleForSceneIndex(scenes, index - 1) ? 0 : offset,
+                barVisibleForSceneIndex(scenes, index) ? 0 : offset,
+                barVisibleForSceneIndex(scenes, index + 1) ? 0 : offset,
+              ],
+            }),
+          },
+        ],
+      };
+    },
+    /**
+     * Don't animate the nav
+     */
+    forLeft: (props) => {
+      return {};
+    },
+    forCenter: (props) => {
+      return {};
+    },
+    forRight: (props) => {
+      return {};
+    },
+    gestures: CardStackPanResponder.forHorizontal,
+  }
+};
+
 export const SlideHorizontal: ExNavigationStyles = {
   configureTransition: configureSpringTransition,
   sceneAnimations: customForHorizontal,


### PR DESCRIPTION
This came from a need to not have the navbar "flash" when screens were transitioning, due to the navbar being rather static (think Facebook's search bar). 

It's possible this is a config or param setting I over-looked ... and if others want this, could see expanding this to allow navbar animation to be set separately or toggled off independently from the screen transition. In the spirit of keeping it simple, this simply creates a new style one can pass in that does not set any transition/fade/animation for the navbar while allowing the rest of the screen to animate in the traditional `NavigationStyles.SlideHorizontal` fashion.

`styles: NavigationStyles.SlideHorizontalFixedNav,`