### PR TITLE
Use measure instead of measureInWindow to avoid position bug with translucent status bar on Android

### DIFF
--- a/src/shared-element/ExNavigationSharedElement.js
+++ b/src/shared-element/ExNavigationSharedElement.js
@@ -106,9 +106,9 @@ export default class SharedElement extends Component {
         return;
       }
 
-      UIManager.measureInWindow(
+      UIManager.measure(
         findNodeHandle(this._el),
-        (x, y, width, height) => {
+        (origX, origY, width, height, x, y) => {
           const store = this.context.sharedElementStore;
           store.dispatch({
             type: 'UPDATE_METRICS_FOR_ELEMENT',


### PR DESCRIPTION
There's a bug with `measureInWindow` in RN with translucent statusbar because it always adds the statusbar height. This uses `measure` instead with does pretty much the same thing but doesn't have that bug (it's actually the proper way to do it since it measures relative to the root view).

Fixes #320 