### PR TITLE
Enable dynamic sliding tabs

### DIFF
--- a/src/ExNavigationReducer.js
+++ b/src/ExNavigationReducer.js
@@ -239,9 +239,13 @@ class ExNavigationReducer {
     const defaultRouteConfig = navigatorState.defaultRouteConfig;
 
     const newChildren = routes.map(child => {
-      const newChild = child.clone();
-      newChild.config = _.merge({}, defaultRouteConfig, child.config);
-      return newChild;
+      if (child.clone) {
+        const newChild = child.clone();
+        newChild.config = _.merge({}, defaultRouteConfig, child.config);
+        return newChild;
+      } else {
+        return child;
+      }
     });
 
     return {

--- a/src/sliding-tab/ExNavigationSlidingTab.js
+++ b/src/sliding-tab/ExNavigationSlidingTab.js
@@ -55,7 +55,7 @@ type Props = {
   renderFooter?: (props: any) => ?React.Element<any>,
   renderLabel?: (routeParams: any) => ?React.Element<any>,
   getRenderLabel?: (props: any) => (routeParams: any) => ?React.Element<any>,
-  scrollEnabled?: boolean,
+  tabBarScrollEnabled?: boolean,
   style?: any,
   swipeEnabled?: boolean,
   tabBarStyle?: any,
@@ -88,7 +88,7 @@ class ExNavigationSlidingTab extends PureComponent<any, Props, State> {
     indicatorStyle: {},
     position: 'top',
     pressColor: 'rgba(0,0,0,0.2)',
-    scrollEnabled: false,
+    tabBarScrollEnabled: false,
     tabStyle: {},
     renderBefore: () => null,
   };
@@ -228,7 +228,7 @@ class ExNavigationSlidingTab extends PureComponent<any, Props, State> {
       tabStyle: this.props.tabStyle,
       labelStyle: this.props.labelStyle,
       renderLabel: renderLabelFn,
-      scrollEnabled: this.props.scrollEnabled,
+      tabBarScrollEnabled: this.props.tabBarScrollEnabled,
       style: [{backgroundColor: this.props.barBackgroundColor}, this.props.tabBarStyle],
     };
 

--- a/src/sliding-tab/ExNavigationSlidingTab.js
+++ b/src/sliding-tab/ExNavigationSlidingTab.js
@@ -55,6 +55,7 @@ type Props = {
   renderFooter?: (props: any) => ?React.Element<any>,
   renderLabel?: (routeParams: any) => ?React.Element<any>,
   getRenderLabel?: (props: any) => (routeParams: any) => ?React.Element<any>,
+  scrollEnabled?: boolean,
   style?: any,
   swipeEnabled?: boolean,
   tabBarStyle?: any,
@@ -87,6 +88,7 @@ class ExNavigationSlidingTab extends PureComponent<any, Props, State> {
     indicatorStyle: {},
     position: 'top',
     pressColor: 'rgba(0,0,0,0.2)',
+    scrollEnabled: false,
     tabStyle: {},
     renderBefore: () => null,
   };
@@ -226,6 +228,7 @@ class ExNavigationSlidingTab extends PureComponent<any, Props, State> {
       tabStyle: this.props.tabStyle,
       labelStyle: this.props.labelStyle,
       renderLabel: renderLabelFn,
+      scrollEnabled: this.props.scrollEnabled,
       style: [{backgroundColor: this.props.barBackgroundColor}, this.props.tabBarStyle],
     };
 

--- a/src/sliding-tab/ExNavigationSlidingTab.js
+++ b/src/sliding-tab/ExNavigationSlidingTab.js
@@ -228,7 +228,7 @@ class ExNavigationSlidingTab extends PureComponent<any, Props, State> {
       tabStyle: this.props.tabStyle,
       labelStyle: this.props.labelStyle,
       renderLabel: renderLabelFn,
-      tabBarScrollEnabled: this.props.tabBarScrollEnabled,
+      scrollEnabled: this.props.tabBarScrollEnabled,
       style: [{backgroundColor: this.props.barBackgroundColor}, this.props.tabBarStyle],
     };
 


### PR DESCRIPTION
This project builds off of #337 (since it edits the same file, I didn't want to worry about conflicts down the road).

It allows the user to update the list of tabs in their app and have the change reflected in the horizontal tabs

Here's an example of the code from the render function in my app:
```javascript
<SlidingTabNavigation
	id="sliding-tab-navigation"
	navigatorUID="sliding-tab-navigation"
	initialTab="shop"
	renderLabel={this.renderLabel}
	barBackgroundColor="#fff"
	indicatorStyle={componentStyles.tabIndicator}
	tabBarScrollEnabled={true}
>
	{
		this.state.tabs.map((tab) => {
			return (
				<SlidingTabNavigationItem
					id={tab.id}
					key={tab.id}
				>
					{tab.component()}
				</SlidingTabNavigationItem>
			);
		})
	}
</SlidingTabNavigation>
```

Later, the app can just update the state with a new set of tabs and the change will be reflected in the UI.