### PR TITLE
Upgrade react-native-tab-view

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-clone-referenced-element": "^1.0.1",
     "react-mixin": "^3.0.5",
     "react-native-drawer-layout": "^1.0.0",
-    "react-native-tab-view": "0.0.42",
+    "react-native-tab-view": "0.0.52",
     "react-redux": "^4.4.5",
     "react-static-container": "^1.0.0",
     "react-timer-mixin": "^0.13.3",

--- a/src/sliding-tab/ExNavigationSlidingTab.js
+++ b/src/sliding-tab/ExNavigationSlidingTab.js
@@ -21,7 +21,7 @@ import ExNavigatorContext from '../ExNavigatorContext';
 import ExNavigationBar from '../ExNavigationBar';
 import ExNavigationSlidingTabItem from './ExNavigationSlidingTabItem';
 import { ExNavigationTabContext } from '../tab/ExNavigationTab';
-import { TabViewAnimated, TabViewPagerAndroid, TabViewPagerScroll, TabBarTop, TabBar } from 'react-native-tab-view';
+import { TabViewAnimated, TabViewPagerAndroid, TabViewPagerScroll, TabBar } from 'react-native-tab-view';
 import { createNavigatorComponent } from '../ExNavigationComponents';
 
 import type ExNavigationContext from '../ExNavigationContext';
@@ -215,7 +215,7 @@ class ExNavigationSlidingTab extends PureComponent<any, Props, State> {
   };
 
   _renderTabBar = (props) => {
-    const TabBarComponent = this.props.position === 'top' ? TabBarTop : TabBar;
+    const TabBarComponent = TabBar;
     const renderLabelFn = this.props.getRenderLabel ?
       this.props.getRenderLabel(props) :
       this.props.renderLabel;


### PR DESCRIPTION
I forked ex-navigation to get sliding tabs to render correctly on iOS. I can confirm that this is working perfectly and would love for it to make it into the main repo. Thanks!