### PR TITLE
Add style for scene in route config

### DIFF
--- a/src/ExNavigationStack.js
+++ b/src/ExNavigationStack.js
@@ -678,7 +678,7 @@ class ExNavigationStack extends PureComponent<any, Props, State> {
     const latestRoute = this._getRouteAtIndex(props.scenes, props.scenes.length - 1);
 
     const latestRouteConfig = latestRoute.config;
-    const { sceneAnimations, gestures } = latestRouteConfig.styles || {};
+    const { sceneAnimations, gestures, style } = latestRouteConfig.styles || {};
 
     const scene: any = props.scene;
     const routeForScene = scene.route;
@@ -692,6 +692,7 @@ class ExNavigationStack extends PureComponent<any, Props, State> {
       route: routeForScene,
       sceneAnimations,
       gestures,
+		style,
       renderScene: this._renderRoute,
     };
 


### PR DESCRIPTION
Hello. I was struggling for few hours how to display modal using ex-navigation. When I get necessary  knowledge I found that new scene always have a default white background and I cannot fix it. I start digging issues without any success. According to https://github.com/exponent/ex-navigation/issues/394 this PR should resolve that problem.

To configure route scene we need to override style from ExNavigationStackItem. So far, it was not passed down from anywhere. In our component we just need to define route as follows:

```
static route = {
		styles: {
			sceneAnimations:() => {},
			style: {
				backgroundColor: 'transparent',
				bottom: 0,
				left: 0,
				position: 'absolute',
				right: 0,
				shadowColor: null,
				shadowOffset: null,
				shadowOpacity: null,
				shadowRadius: null,
				top: 0,
			}
		}
	};
```

And we can easily use react-native Modal component as follows:
```
render() {
		return <Modal
			animationType={"slide"}
			visible={true}
			transparent={true}>
			<View style={{flex:1, backgroundColor:'red'}}>
				<Text>Modal View</Text>
				<TouchableOpacity onPress={() => this.props.navigator.pop()}>
					<Text>Klik</Text>
				</TouchableOpacity>
			</View>
		</Modal>
	}
```

Sorry for PR code formatting. If place where I receive and pass data style is wrong, I will appreciate if any contributor could fix it. Also, hope I made everything ok with PR - it's my first one :)  