### PR TITLE
Add `before` and `after` props `NavigationBar.Title`.

### DIFF
--- a/src/ExNavigationBar.js
+++ b/src/ExNavigationBar.js
@@ -34,10 +34,11 @@ const BACK_BUTTON_HIT_SLOP = { top: 0, bottom: 0, left: 0, right: 30 };
 
 class ExNavigationBarTitle extends PureComponent {
   render() {
-    const { children, style, textStyle, tintColor } = this.props;
+    const { children, before, after, style, textStyle, tintColor } = this.props;
 
     return (
       <View style={[titleStyles.title, style]}>
+        {before}
         <Text numberOfLines={1} style={[
           titleStyles.titleText,
           tintColor ? {color: tintColor} : null,
@@ -45,6 +46,7 @@ class ExNavigationBarTitle extends PureComponent {
         ]}>
           {children}
         </Text>
+        {after}
       </View>
     );
   }


### PR DESCRIPTION
This helps insert non-text components before and after title text in the title area.

Adding things like icons to the title is impossible when all of NavigationBar.Title’s children are text.